### PR TITLE
상대주소로 된 url 접근 불가 수정

### DIFF
--- a/RULES/GIT/PR/PULL_REQUEST.md
+++ b/RULES/GIT/PR/PULL_REQUEST.md
@@ -1,11 +1,11 @@
 # PULL REQUEST RULE
 
-기본적으로 마스터에 코드를 수정해서 직접 푸쉬하는 행위는 지양하고 있습니다. 
+기본적으로 마스터에 코드를 수정해서 직접 푸쉬하는 행위는 지양하고 있습니다.
 
 저희는 fork & pr 방식으로 저희 레포지토리에 수정을 하는 방식을 지향합니다.
 이로인해 머리가 어지러우신 분들을 위해 방법을 간단히 정리해 드리고자합니다❗️❗️
 
-### 1. fork 진행법 
+### 1. fork 진행법
 ---
 * DSC-2019-JEJU에서 운영하는 레포지토리를 들어가시고 우측 상단에 들어가시면 다음과 같은 그림을 보실 수 있습니다.
 ![forkbutton](./IMAGE/FORK_EXAMPLE.png)
@@ -56,7 +56,7 @@ $ git pull upstream master
 
 * 편집한 부분을 올릴 차례입니다. 커밋 메시지 작성은 하단의 사이트를 통해 커밋한 상태라고 가정하겠습니다.
 
-[Commit 작성 규칙](../GIT/COMMIT/COMMIT_RULE.md)
+[Commit 작성 규칙](https://dsc-jeju-2019.github.io/DSCJEJU/RULES/GIT/PR/PULL_REQUEST)
 
 
 * 커밋을 완료하고 푸쉬를 진행하게되면 자신의 레포지토리로 다음과 같은 형태로 문구가 출력 될 것입니다. 여기서 Pull Request를 클릭하겠습니다.


### PR DESCRIPTION
RULES/GIT/PR/PULL_REQUEST.md 파일의 GIT COMMIT RULE 버튼클릭시 상대주소가 안먹히는걸 수정함.
github page 를 통해 접근함을 가정으로 절대주소로 바꿔뒀습니다.